### PR TITLE
Add default hit and miss action and a few usability improvements

### DIFF
--- a/include/net/p4tc.h
+++ b/include/net/p4tc.h
@@ -165,6 +165,8 @@ struct p4tc_table_class {
 	struct tc_action            **tbc_preacts;
 	int                         tbc_num_preacts;
 	struct tc_action            **tbc_postacts;
+	struct tc_action            **tbc_default_hitact;
+	struct tc_action            **tbc_default_missact;
 	int                         tbc_num_postacts;
 	u32                         tbc_count;
 	u32                         tbc_curr_count;

--- a/include/net/p4tc.h
+++ b/include/net/p4tc.h
@@ -364,6 +364,8 @@ struct p4tc_table_class *tcf_tclass_find_byid(struct p4tc_pipeline *pipeline,
 struct p4tc_table_key *tcf_table_key_find(struct p4tc_table_class *tclass,
 					  const u32 key_id);
 void *tcf_tclass_fetch(struct sk_buff *skb, void *tbc_value_ops);
+int tcf_tclass_try_set_state_ready(struct p4tc_pipeline *pipeline,
+				   struct netlink_ext_ack *extack);
 
 int p4tc_tinst_init(struct p4tc_table_instance *tinst,
 		    struct p4tc_pipeline *pipeline,

--- a/include/uapi/linux/p4tc.h
+++ b/include/uapi/linux/p4tc.h
@@ -191,6 +191,8 @@ enum {
 	P4TC_TCLASS_PREACTIONS, /* nested table preactions */
 	P4TC_TCLASS_KEYS, /* nested table keys */
 	P4TC_TCLASS_POSTACTIONS, /* nested table postactions */
+	P4TC_TCLASS_DEFAULT_HIT, /* default hit action */
+	P4TC_TCLASS_DEFAULT_MISS, /* default miss action */
 	__P4TC_TCLASS_MAX
 };
 #define P4TC_TCLASS_MAX __P4TC_TCLASS_MAX

--- a/net/sched/p4tc/p4tc_pipeline.c
+++ b/net/sched/p4tc/p4tc_pipeline.c
@@ -113,6 +113,8 @@ static int tcf_pipeline_put(struct net *net,
 static inline int pipeline_try_set_state_ready(struct p4tc_pipeline *pipeline,
 					       struct netlink_ext_ack *extack)
 {
+	int ret;
+
 	if (pipeline->curr_table_classes != pipeline->num_table_classes) {
 		NL_SET_ERR_MSG(extack,
 			       "Must have all table classes defined to update state to ready");
@@ -130,6 +132,9 @@ static inline int pipeline_try_set_state_ready(struct p4tc_pipeline *pipeline,
 			       "Must specify pipeline postactions before sealing");
 		return -EINVAL;
 	}
+	ret = tcf_tclass_try_set_state_ready(pipeline, extack);
+	if (ret < 0)
+		return ret;
 
 	pipeline->p_state = P4TC_STATE_READY;
 	return true;

--- a/net/sched/p4tc/p4tc_pipeline.c
+++ b/net/sched/p4tc/p4tc_pipeline.c
@@ -95,21 +95,41 @@ static int tcf_pipeline_put(struct net *net,
 	 * will use them. So there is no need to free them in the rcu
 	 * callback. We can just free them here
 	 */
-	tcf_action_destroy(pipeline->preacts, TCA_ACT_UNBIND);
-	kfree(pipeline->preacts);
+	if (pipeline->preacts) {
+		tcf_action_destroy(pipeline->preacts, TCA_ACT_UNBIND);
+		kfree(pipeline->preacts);
+	}
 
-	tcf_action_destroy(pipeline->postacts, TCA_ACT_UNBIND);
-	kfree(pipeline->postacts);
+	if (pipeline->postacts) {
+		tcf_action_destroy(pipeline->postacts, TCA_ACT_UNBIND);
+		kfree(pipeline->postacts);
+	}
 
 	call_rcu(&pipeline->rcu, tcf_pipeline_destroy);
 
 	return 0;
 }
 
-static inline bool pipeline_try_set_state_ready(struct p4tc_pipeline *pipeline)
+static inline int pipeline_try_set_state_ready(struct p4tc_pipeline *pipeline,
+					       struct netlink_ext_ack *extack)
 {
-	if (pipeline->curr_table_classes != pipeline->num_table_classes)
-		return false;
+	if (pipeline->curr_table_classes != pipeline->num_table_classes) {
+		NL_SET_ERR_MSG(extack,
+			       "Must have all table classes defined to update state to ready");
+		return -EINVAL;
+	}
+
+	if (!pipeline->preacts) {
+		NL_SET_ERR_MSG(extack,
+			       "Must specify pipeline preactions before sealing");
+		return -EINVAL;
+	}
+
+	if (!pipeline->postacts) {
+		NL_SET_ERR_MSG(extack,
+			       "Must specify pipeline postactions before sealing");
+		return -EINVAL;
+	}
 
 	pipeline->p_state = P4TC_STATE_READY;
 	return true;
@@ -221,9 +241,8 @@ tcf_pipeline_create(struct net *net, struct nlmsghdr *n,
 		}
 		pipeline->num_preacts = ret;
 	} else {
-		NL_SET_ERR_MSG(extack, "Must specify pipeline preactions");
-		ret = -EINVAL;
-		goto idr_rm;
+		pipeline->preacts = NULL;
+		pipeline->num_preacts = 0;
 	}
 
 	if (tb[P4TC_PIPELINE_POSTACTIONS]) {
@@ -243,9 +262,8 @@ tcf_pipeline_create(struct net *net, struct nlmsghdr *n,
 		}
 		pipeline->num_postacts = ret;
 	} else {
-		NL_SET_ERR_MSG(extack, "Must specify pipeline postactions");
-		ret = -EINVAL;
-		goto preactions_destroy;
+		pipeline->postacts = NULL;
+		pipeline->num_postacts = 0;
 	}
 
 	idr_init(&pipeline->p_act_idr);
@@ -268,8 +286,10 @@ tcf_pipeline_create(struct net *net, struct nlmsghdr *n,
 	return pipeline;
 
 preactions_destroy:
-	tcf_action_destroy(pipeline->preacts, TCA_ACT_UNBIND);
-	kfree(pipeline->preacts);
+	if (pipeline->preacts) {
+		tcf_action_destroy(pipeline->preacts, TCA_ACT_UNBIND);
+		kfree(pipeline->preacts);
+	}
 
 idr_rm:
 	idr_remove(&pipeline_idr, pipeid);
@@ -430,12 +450,9 @@ tcf_pipeline_update(struct net *net, struct nlmsghdr *n,
 	}
 
 	if (tb[P4TC_PIPELINE_STATE]) {
-		if (!pipeline_try_set_state_ready(pipeline)) {
-			NL_SET_ERR_MSG(extack,
-				       "Must have all table classes defined to update state to ready");
-			ret = -EINVAL;
+		ret = pipeline_try_set_state_ready(pipeline, extack);
+		if (ret < 0)
 			goto postactions_destroy;
-		}
 		tcf_meta_fill_user_offsets(pipeline);
 	}
 
@@ -444,14 +461,18 @@ tcf_pipeline_update(struct net *net, struct nlmsghdr *n,
 	if (num_table_classes)
 		pipeline->num_table_classes = num_table_classes;
 	if (preacts) {
-		tcf_action_destroy(pipeline->preacts, TCA_ACT_UNBIND);
-		kfree(pipeline->preacts);
+		if (pipeline->preacts) {
+			tcf_action_destroy(pipeline->preacts, TCA_ACT_UNBIND);
+			kfree(pipeline->preacts);
+		}
 		pipeline->preacts = preacts;
 		pipeline->num_preacts = num_preacts;
 	}
 	if (postacts) {
-		tcf_action_destroy(pipeline->postacts, TCA_ACT_UNBIND);
-		kfree(pipeline->postacts);
+		if (pipeline->postacts) {
+			tcf_action_destroy(pipeline->postacts, TCA_ACT_UNBIND);
+			kfree(pipeline->postacts);
+		}
 		pipeline->postacts = postacts;
 		pipeline->num_postacts = num_postacts;
 	}
@@ -518,15 +539,19 @@ static int _tcf_pipeline_fill_nlmsg(struct sk_buff *skb,
 	if (nla_put_u8(skb, P4TC_PIPELINE_STATE, pipeline->p_state))
 		goto out_nlmsg_trim;
 
-	preacts = nla_nest_start(skb, P4TC_PIPELINE_PREACTIONS);
-	if (tcf_action_dump(skb, pipeline->preacts, 0, 0, false) < 0)
-		goto out_nlmsg_trim;
-	nla_nest_end(skb, preacts);
+	if (pipeline->preacts) {
+		preacts = nla_nest_start(skb, P4TC_PIPELINE_PREACTIONS);
+		if (tcf_action_dump(skb, pipeline->preacts, 0, 0, false) < 0)
+			goto out_nlmsg_trim;
+		nla_nest_end(skb, preacts);
+	}
 
-	postacts = nla_nest_start(skb, P4TC_PIPELINE_POSTACTIONS);
-	if (tcf_action_dump(skb, pipeline->postacts, 0, 0, false) < 0)
-		goto out_nlmsg_trim;
-	nla_nest_end(skb, postacts);
+	if (pipeline->postacts) {
+		postacts = nla_nest_start(skb, P4TC_PIPELINE_POSTACTIONS);
+		if (tcf_action_dump(skb, pipeline->postacts, 0, 0, false) < 0)
+			goto out_nlmsg_trim;
+		nla_nest_end(skb, postacts);
+	}
 
 	nla_nest_end(skb, nest);
 

--- a/tools/testing/selftests/tc-testing/tc-tests/p4tc/pipeline.json
+++ b/tools/testing/selftests/tc-testing/tc-tests/p4tc/pipeline.json
@@ -154,7 +154,7 @@
     },
     {
         "id": "c0dc",
-        "name": "Try to create pipeline without preactions",
+        "name": "Create pipeline without preactions",
         "category": [
             "p4tc",
             "template",
@@ -181,11 +181,51 @@
             ]
         ],
         "cmdUnderTest": "$TC p4template create pipeline/ptables pipeid 22 maxrules 1 numtclasses 2 postactions action gact index 1",
-        "expExitCode": "255",
+        "expExitCode": "0",
         "verifyCmd": "$TC -j p4template get pipeline/ptables",
         "matchCount": "1",
-        "matchPattern": "Error: Pipeline name not found.*",
+        "matchJSON": [
+            {
+                "pname": "ptables",
+                "pipeid": 22,
+                "obj": "pipeline"
+            },
+            {
+                "templates": [
+                    {
+                        "pmaxrules": 1,
+                        "pnumtclasses": 2,
+                        "pstate": "not ready",
+                        "postactions": {
+                            "actions": [
+                                {
+                                    "order": 1,
+                                    "kind": "gact",
+                                    "control_action": {
+                                        "type": "pass"
+                                    },
+                                    "prob": {
+                                        "random_type": "none",
+                                        "control_action": {
+                                            "type": "pass"
+                                        },
+                                        "val": 0
+                                    },
+                                    "index": 1,
+                                    "ref": 2,
+                                    "bind": 1
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
         "teardown": [
+            [
+                "$TC p4template del pipeline/ptables",
+                0
+            ],
             [
                 "$TC actions flush action gact",
                 0
@@ -221,11 +261,51 @@
             ]
         ],
         "cmdUnderTest": "$TC p4template create pipeline/ptables pipeid 22 maxrules 1 numtclasses 2 preactions action gact index 1",
-        "expExitCode": "255",
+        "expExitCode": "0",
         "verifyCmd": "$TC -j p4template get pipeline/ptables",
         "matchCount": "1",
-        "matchPattern": "Error: Pipeline name not found.*",
+        "matchJSON": [
+            {
+                "pname": "ptables",
+                "pipeid": 22,
+                "obj": "pipeline"
+            },
+            {
+                "templates": [
+                    {
+                        "pmaxrules": 1,
+                        "pnumtclasses": 2,
+                        "pstate": "not ready",
+                        "preactions": {
+                            "actions": [
+                                {
+                                    "order": 1,
+                                    "kind": "gact",
+                                    "index": 1,
+                                    "ref": 2,
+                                    "bind": 1,
+                                    "control_action": {
+                                        "type": "pass"
+                                    },
+                                    "prob": {
+                                        "random_type": "none",
+                                        "control_action": {
+                                            "type": "pass"
+                                        },
+                                        "val": 0
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
         "teardown": [
+            [
+                "$TC p4template del pipeline/ptables",
+                0
+            ],
             [
                 "$TC actions flush action gact",
                 0


### PR DESCRIPTION
- Don't make preactions and postactions mandatory in the pipeline creation command
- Don't make table class postactions and key actions mandatory in table class creation command
- Add default hit and miss action to the table class
