### PR TITLE
ci/cd: make clang-analyzer and sparse actions more strict

### DIFF
--- a/.github/workflows/sparse.yaml
+++ b/.github/workflows/sparse.yaml
@@ -15,7 +15,13 @@ jobs:
         with:
           fetch-depth: 0
       - run: |
-          sudo apt update && sudo apt install -y gawk flex bison openssl libssl-dev libelf-dev libudev-dev libpci-dev libiberty-dev sparse
+          sudo apt update && sudo apt install -y gawk flex bison openssl libssl-dev libelf-dev libudev-dev libpci-dev libiberty-dev
+          pushd .
+          git clone git://git.kernel.org/pub/scm/devel/sparse/sparse.git
+          cd sparse
+          make
+          sudo PREFIX=/usr make install
+          popd
           make tinyconfig
           ./scripts/config --enable NET
           ./scripts/config --enable NET_INGRESS
@@ -27,4 +33,8 @@ jobs:
           ./scripts/config --enable NET_TC_SKB_EXT
           ./scripts/config --enable NET_P4_TC
           make listnewconfig >> .config
-          make C=2 net/
+          make C=2 net/sched/ > sparse-logs 2>&1
+          if grep -q "p4tc_.*\.c:" sparse-logs; then
+            cat sparse-logs
+            exit 1
+          fi

--- a/.github/workflows/static-analyzer.yaml
+++ b/.github/workflows/static-analyzer.yaml
@@ -27,5 +27,10 @@ jobs:
           ./scripts/config --enable NET_TC_SKB_EXT
           ./scripts/config --enable NET_P4_TC
           make CC=clang listnewconfig >> .config
-          make CC=clang -j$(nproc) clang-analyzer 2> check-logs
-          cat check-logs | grep "p4tc\_.*"
+          make CC=clang -j$(nproc) net/sched/
+          ./scripts/clang-tools/gen_compile_commands.py
+          clang-tidy -p compile_commands.json --checks=-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling net/sched/p4tc/*.c > check-logs
+          if grep -q "p4tc_.*\.c:" check-logs; then
+            cat check-logs
+            exit 1
+          fi


### PR DESCRIPTION
These actions were not given the proper attention and we missed some important warnings. Make them fail if something shows up instead of the always green due to false positives.

Also makes the clang analyzer action a bit faster