### PR TITLE
A few kernel bug fixes

### DIFF
--- a/net/sched/cls_p4.c
+++ b/net/sched/cls_p4.c
@@ -32,8 +32,8 @@ static int p4_classify(struct sk_buff *skb, const struct tcf_proto *tp,
 	struct cls_p4_head *head = rcu_dereference_bh(tp->root);
 	struct p4tc_pipeline *pipeline = head->pipeline;
 	struct tcf_result p4res = { };
+	int rc = 0;
 	struct p4tc_skb_ext *p4tc_ext;
-	int rc;
 
 	if (unlikely(!head)) {
 		pr_err("P4 classifier not found\n");
@@ -47,7 +47,12 @@ static int p4_classify(struct sk_buff *skb, const struct tcf_proto *tp,
 	}
 
 	if (refcount_read(&pipeline->p_hdrs_used) > 1)
-		tcf_skb_parse(skb, p4tc_ext, pipeline->parser);
+		rc = tcf_skb_parse(skb, p4tc_ext, pipeline->parser);
+
+	if (rc > 0) {
+		pr_warn("P4 parser error %d\n", rc);
+		return TC_ACT_SHOT;
+	}
 
 	rc = tcf_action_exec(skb, pipeline->preacts, pipeline->num_preacts,
 			     &p4res);

--- a/net/sched/cls_p4.c
+++ b/net/sched/cls_p4.c
@@ -265,6 +265,9 @@ static int p4_dump(struct net *net, struct tcf_proto *tp, void *fh,
 	if (!nest)
 		goto nla_put_failure;
 
+	if (nla_put_string(skb, TCA_P4_PNAME, head->pipeline->common.name))
+		goto nla_put_failure;
+
 	if (head->res.classid &&
 	    nla_put_u32(skb, TCA_P4_CLASSID, head->res.classid))
 		goto nla_put_failure;

--- a/net/sched/p4tc/p4tc_parser_api.c
+++ b/net/sched/p4tc/p4tc_parser_api.c
@@ -106,8 +106,9 @@ int tcf_skb_parse(struct sk_buff *skb, struct p4tc_skb_ext *p4tc_skb_ext,
 		  struct p4tc_parser *parser)
 {
 	void *hdr = skb_mac_header(skb);
+	size_t pktlen = skb_mac_header_len(skb) + skb->len;
 
-	return __kparser_parse(parser->kparser, hdr, skb->len,
+	return __kparser_parse(parser->kparser, hdr, pktlen,
 			       p4tc_skb_ext->p4tc_ext->hdrs, HEADER_MAX_LEN);
 }
 


### PR DESCRIPTION
- Pass program name to user space when dumping P4 classifier
- Handle possible parser error
- Include mac header length when calling tcf_skb_parse
- Call create_bitops type callback for params, header fields and registers

